### PR TITLE
[Migrate] Built-in transition with `AnimatedContent`

### DIFF
--- a/navigator-compose/navigator-compose/build.gradle
+++ b/navigator-compose/navigator-compose/build.gradle
@@ -40,7 +40,6 @@ android {
     }
     composeOptions {
         kotlinCompilerExtensionVersion compose_version
-        kotlinCompilerVersion '1.4.32'
     }
 
     packagingOptions {
@@ -54,7 +53,8 @@ dependencies {
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.compose.ui:ui-util:$compose_version"
-    implementation 'androidx.activity:activity-compose:1.3.0-beta01'
+    implementation "androidx.compose.animation:animation:$compose_version"
+    implementation 'androidx.activity:activity-compose:1.3.0'
 
     lintPublish project(":navigator-compose-lint")
 

--- a/navigator-compose/navigator-compose/src/main/java/com/kpstv/navigation/compose/DefaultTransitions.kt
+++ b/navigator-compose/navigator-compose/src/main/java/com/kpstv/navigation/compose/DefaultTransitions.kt
@@ -1,13 +1,17 @@
+@file:OptIn(ExperimentalAnimationApi::class)
+
 package com.kpstv.navigation.compose
 
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.animation.*
+import androidx.compose.animation.core.tween
+
+//TODO: Fix transitions & change comments, Each transition is with respect to one composable
 
 public val None: TransitionKey get() = NoneTransition.key
 
 internal val NoneTransition: NavigatorTransition = object : NavigatorTransition() {
-    override val forwardTransition: ComposeTransition = ComposeTransition { modifier, _, _, _ -> modifier }
-    override val backwardTransition: ComposeTransition = ComposeTransition { modifier, _, _, _ -> modifier }
+    override val forwardTransition: EnterTransition = EnterTransition.None
+    override val backwardTransition: ExitTransition = ExitTransition.None
 }
 
 /**
@@ -16,12 +20,8 @@ internal val NoneTransition: NavigatorTransition = object : NavigatorTransition(
 public val Fade: TransitionKey get() = FadeTransition.key
 
 internal val FadeTransition: NavigatorTransition = object : NavigatorTransition() {
-    override val forwardTransition: ComposeTransition = ComposeTransition { modifier, _, _, progress ->
-        modifier.then(Modifier.graphicsLayer { alpha = progress }) // fade-in
-    }
-    override val backwardTransition: ComposeTransition = ComposeTransition { modifier, _, _, progress ->
-        modifier.then(Modifier.graphicsLayer { alpha = 1 - progress }) // fade-out
-    }
+    override val forwardTransition: EnterTransition = fadeIn(animationSpec = tween(300))
+    override val backwardTransition: ExitTransition = fadeOut(animationSpec = tween(300))
 }
 
 /**
@@ -33,12 +33,10 @@ internal val FadeTransition: NavigatorTransition = object : NavigatorTransition(
 public val SlideRight: TransitionKey get() = SlideRightTransition.key
 
 internal val SlideRightTransition: NavigatorTransition = object : NavigatorTransition() {
-    override val forwardTransition: ComposeTransition = ComposeTransition { modifier, width, _, progress ->
-        modifier.then(Modifier.graphicsLayer { this.translationX = width + (-1) * width * progress }) // slide-in-right
-    }
-    override val backwardTransition: ComposeTransition = ComposeTransition { modifier, width, _, progress ->
-        modifier.then(Modifier.graphicsLayer { this.translationX = width * (progress) }) // slide-out-right
-    }
+    override val forwardTransition: EnterTransition =
+        slideInHorizontally(initialOffsetX = { it }, animationSpec = tween(300))
+    override val backwardTransition: ExitTransition =
+        slideOutHorizontally(targetOffsetX = { it }, animationSpec = tween(300))
 }
 
 /**
@@ -50,10 +48,8 @@ internal val SlideRightTransition: NavigatorTransition = object : NavigatorTrans
 public val SlideLeft: TransitionKey get() = SlideLeftTransition.key
 
 internal val SlideLeftTransition: NavigatorTransition = object : NavigatorTransition() {
-    override val forwardTransition: ComposeTransition = ComposeTransition { modifier, width, _, progress ->
-        modifier.then(Modifier.graphicsLayer { this.translationX = width * (1 - progress) * (-1) }) // slide-in-left
-    }
-    override val backwardTransition: ComposeTransition = ComposeTransition { modifier, width, _, progress ->
-        modifier.then(Modifier.graphicsLayer { this.translationX = (-1) * width * (progress) }) // slide-out-left
-    }
+    override val forwardTransition: EnterTransition =
+        slideInHorizontally(initialOffsetX = { -it }, animationSpec = tween(300))
+    override val backwardTransition: ExitTransition =
+        slideOutHorizontally(targetOffsetX = { -it }, animationSpec = tween(300))
 }

--- a/navigator-compose/samples/basic-sample/src/main/java/com/kpstv/navigation/compose/sample/CustomTransitions.kt
+++ b/navigator-compose/samples/basic-sample/src/main/java/com/kpstv/navigation/compose/sample/CustomTransitions.kt
@@ -1,5 +1,10 @@
+@file:OptIn(ExperimentalAnimationApi::class)
+
 package com.kpstv.navigation.compose.sample
 
+import androidx.compose.animation.*
+import androidx.compose.animation.core.tween
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import com.kpstv.navigation.compose.ComposeTransition
@@ -9,39 +14,21 @@ val SlideWithFadeRight get() = SlideWithFadeRightTransition.key
 val SlideWithFadeLeft get() = SlideWithFadeLeftTransition.key
 
 internal val SlideWithFadeRightTransition = object : NavigatorTransition() {
-    override val forwardTransition: ComposeTransition = ComposeTransition { modifier, width, _, progress ->
-        modifier.then(Modifier.graphicsLayer {
-            alpha = progress
-            scaleX = progress
-            scaleY = progress
-            translationX = width * (1 - progress)
-        })
-    }
-    override val backwardTransition: ComposeTransition = ComposeTransition { modifier, width, _, progress ->
-        modifier.then(Modifier.graphicsLayer {
-            alpha = 1 - progress
-            scaleX = 1 - progress
-            scaleY = 1 - progress
-            translationX = width * progress
-        })
-    }
+    override val forwardTransition: EnterTransition = fadeIn(animationSpec = tween(300)) +
+            expandVertically(expandFrom = Alignment.CenterVertically, animationSpec = tween(300)) +
+            slideInHorizontally(initialOffsetX = { it }, animationSpec = tween(300))
+
+    override val backwardTransition: ExitTransition = fadeOut(animationSpec = tween(300)) +
+            shrinkVertically(shrinkTowards = Alignment.CenterVertically, animationSpec = tween(300)) +
+            slideOutHorizontally(targetOffsetX = { it }, animationSpec = tween(300))
 }
 
 internal val SlideWithFadeLeftTransition = object : NavigatorTransition() {
-    override val forwardTransition: ComposeTransition = ComposeTransition { modifier, width, _, progress ->
-        modifier.then(Modifier.graphicsLayer {
-            alpha = progress
-            scaleX = progress
-            scaleY = progress
-            translationX = width * (1 - progress) * (-1)
-        })
-    }
-    override val backwardTransition: ComposeTransition = ComposeTransition { modifier, width, _, progress ->
-        modifier.then(Modifier.graphicsLayer {
-            alpha = 1 - progress
-            scaleX = 1 - progress
-            scaleY = 1 - progress
-            translationX =  (-1) * width * (progress)
-        })
-    }
+    override val forwardTransition: EnterTransition = fadeIn(animationSpec = tween(300)) +
+            expandVertically(expandFrom = Alignment.CenterVertically, animationSpec = tween(300)) +
+            slideInHorizontally(initialOffsetX = { -it }, animationSpec = tween(300))
+
+    override val backwardTransition: ExitTransition = fadeOut(animationSpec = tween(300)) +
+            shrinkVertically(shrinkTowards = Alignment.CenterVertically, animationSpec = tween(300)) +
+            slideOutHorizontally(targetOffsetX = { -it }, animationSpec = tween(300))
 }

--- a/navigator-compose/samples/basic-sample/src/main/java/com/kpstv/navigation/compose/sample/MainActivity.kt
+++ b/navigator-compose/samples/basic-sample/src/main/java/com/kpstv/navigation/compose/sample/MainActivity.kt
@@ -61,17 +61,18 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    override fun onBackPressed() {
+   /* override fun onBackPressed() {
         // Show the dialog when navigation history contains 1 item
         // & close the dialog when dialog history contains the close dialog.
         if (controller.getAllHistory().count() > 1 ||
-            controller.getAllDialogHistory().lastOrNull() is CloseDialog
+            controller.getAllDialogHistory().lastOrNull() is CloseDialog ||
+            navigator.suppressBackPress
         ) {
             super.onBackPressed()
         } else {
             controller.showDialog(CloseDialog)
         }
-    }
+    }*/
 }
 
 sealed interface StartRoute : Route {


### PR DESCRIPTION
This uses the new experimental `AnimatedContent` API instead of modifying modifiers which is what `navigator-compose` does.