### PR TITLE
[Adding] New APIs for more control over `backstack`.  

### DIFF
--- a/.github/workflows/build-compose.yml
+++ b/.github/workflows/build-compose.yml
@@ -75,6 +75,7 @@ jobs:
 
       - name: Run Unit tests
         run: |
+          ./gradlew navigator-compose:test
           ./gradlew navigator-compose-lint:test
 
       # Test samples or code

--- a/navigator-compose/.idea/deploymentTargetDropDown.xml
+++ b/navigator-compose/.idea/deploymentTargetDropDown.xml
@@ -12,6 +12,6 @@
         </deviceKey>
       </Target>
     </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2021-09-01T13:51:30.813698Z" />
+    <timeTargetWasSelectedWithDropDown value="2021-10-02T09:14:20.881945500Z" />
   </component>
 </project>

--- a/navigator-compose/CHANGELOG.md
+++ b/navigator-compose/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- **Updated**: Jetpack Compose to version `v1.0.3` (requires Kotlin `v1.5.30`).
+- **Breaking Change**: `popUpTo` doesn't require destination instance, instead they now accept `Route` keys.
+- **Added**: `goBackUntil(dest)` similar to popUntil for `Controller<T>` as well as navigator.
+- **Added**: Exposed `navigator.goBack()` for managing backstack or manual handling of `onBackPressed()`.
+
 ## Version `0.1-alpha22` _(2021-09-29)_
 
 - **Breaking Change**: `rememberController` renamed to `rememberNavController`.

--- a/navigator-compose/build.gradle
+++ b/navigator-compose/build.gradle
@@ -3,9 +3,9 @@ apply plugin: 'binary-compatibility-validator'
 
 buildscript {
     ext {
-        kotlin_version = '1.5.21'
+        kotlin_version = '1.5.30'
         lintVersion = '30.1.0-alpha03'
-        compose_version = '1.0.2'
+        compose_version = '1.0.3'
         versions = [
                 "navigator_compose": "0.1-alpha22"
         ]

--- a/navigator-compose/navigator-compose/api/navigator-compose.api
+++ b/navigator-compose/navigator-compose/api/navigator-compose.api
@@ -8,6 +8,9 @@ public final class com/kpstv/navigation/compose/ComposeNavigator {
 	public final fun getAllKeys ()Ljava/util/List;
 	public final fun getHistory (Lkotlin/reflect/KClass;)Ljava/util/List;
 	public final fun getSuppressBackPress ()Z
+	public final fun goBack ()Lcom/kpstv/navigation/compose/Route;
+	public final fun goBackUntil (Lkotlin/reflect/KClass;Z)Z
+	public static synthetic fun goBackUntil$default (Lcom/kpstv/navigation/compose/ComposeNavigator;Lkotlin/reflect/KClass;ZILjava/lang/Object;)Z
 	public final fun onSaveInstanceState (Landroid/os/Bundle;)V
 	public final fun setSuppressBackPress (Z)V
 }
@@ -34,6 +37,8 @@ public final class com/kpstv/navigation/compose/ComposeNavigator$Controller {
 	public final fun getCurrentRouteAsFlow ()Lkotlinx/coroutines/flow/Flow;
 	public final fun getEnableDialogOverlay ()Z
 	public final fun goBack ()Lcom/kpstv/navigation/compose/Route;
+	public final fun goBackUntil (Lkotlin/reflect/KClass;Z)Ljava/util/List;
+	public static synthetic fun goBackUntil$default (Lcom/kpstv/navigation/compose/ComposeNavigator$Controller;Lkotlin/reflect/KClass;ZILjava/lang/Object;)Ljava/util/List;
 	public final fun navigateTo (Lcom/kpstv/navigation/compose/Route;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun navigateTo$default (Lcom/kpstv/navigation/compose/ComposeNavigator$Controller;Lcom/kpstv/navigation/compose/Route;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public final fun setEnableDialogOverlay (Z)V
@@ -79,8 +84,8 @@ public final class com/kpstv/navigation/compose/NavOptions {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getSingleTop ()Z
 	public fun hashCode ()I
-	public final fun popUpTo (Lcom/kpstv/navigation/compose/Route;Lkotlin/jvm/functions/Function1;)V
-	public static synthetic fun popUpTo$default (Lcom/kpstv/navigation/compose/NavOptions;Lcom/kpstv/navigation/compose/Route;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public final fun popUpTo (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun popUpTo$default (Lcom/kpstv/navigation/compose/NavOptions;Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public final fun setSingleTop (Z)V
 	public fun toString ()Ljava/lang/String;
 	public final fun withAnimation (Lkotlin/jvm/functions/Function1;)V
@@ -110,12 +115,12 @@ public final class com/kpstv/navigation/compose/NavOptions$NavAnimation : androi
 
 public final class com/kpstv/navigation/compose/NavOptions$PopUpOptions {
 	public static final field $stable I
-	public fun <init> (Lcom/kpstv/navigation/compose/Route;ZZ)V
-	public synthetic fun <init> (Lcom/kpstv/navigation/compose/Route;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lkotlin/reflect/KClass;ZZ)V
+	public synthetic fun <init> (Lkotlin/reflect/KClass;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component2 ()Z
 	public final fun component3 ()Z
-	public final fun copy (Lcom/kpstv/navigation/compose/Route;ZZ)Lcom/kpstv/navigation/compose/NavOptions$PopUpOptions;
-	public static synthetic fun copy$default (Lcom/kpstv/navigation/compose/NavOptions$PopUpOptions;Lcom/kpstv/navigation/compose/Route;ZZILjava/lang/Object;)Lcom/kpstv/navigation/compose/NavOptions$PopUpOptions;
+	public final fun copy (Lkotlin/reflect/KClass;ZZ)Lcom/kpstv/navigation/compose/NavOptions$PopUpOptions;
+	public static synthetic fun copy$default (Lcom/kpstv/navigation/compose/NavOptions$PopUpOptions;Lkotlin/reflect/KClass;ZZILjava/lang/Object;)Lcom/kpstv/navigation/compose/NavOptions$PopUpOptions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAll ()Z
 	public final fun getInclusive ()Z
@@ -148,5 +153,8 @@ public final class com/kpstv/navigation/compose/TransitionKey : android/os/Parce
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public abstract interface annotation class com/kpstv/navigation/compose/UnstableNavigatorApi : java/lang/annotation/Annotation {
 }
 

--- a/navigator-compose/navigator-compose/build.gradle
+++ b/navigator-compose/navigator-compose/build.gradle
@@ -65,6 +65,7 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
+    androidTestImplementation "org.jetbrains.kotlin:kotlin-reflect:1.5.21"
     debugImplementation "androidx.compose.ui:ui-test-manifest:1.0.0-beta09"
 }
 

--- a/navigator-compose/navigator-compose/build.gradle
+++ b/navigator-compose/navigator-compose/build.gradle
@@ -62,10 +62,11 @@ dependencies {
     lintPublish project(":navigator-compose-lint")
 
     testImplementation 'junit:junit:4.+'
+    testImplementation "org.jetbrains.kotlin:kotlin-reflect:1.5.21"
+    androidTestImplementation "org.jetbrains.kotlin:kotlin-reflect:1.5.21"
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
-    androidTestImplementation "org.jetbrains.kotlin:kotlin-reflect:1.5.21"
     debugImplementation "androidx.compose.ui:ui-test-manifest:1.0.0-beta09"
 }
 

--- a/navigator-compose/navigator-compose/src/androidTest/java/com/kpstv/navigation/compose/ComposeNavigatorTests.kt
+++ b/navigator-compose/navigator-compose/src/androidTest/java/com/kpstv/navigation/compose/ComposeNavigatorTests.kt
@@ -10,6 +10,7 @@ import com.kpstv.navigation.compose.test.R
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import kotlin.reflect.full.createInstance
 
 @RunWith(AndroidJUnit4::class)
 public class ComposeNavigatorTests {
@@ -386,6 +387,31 @@ public class ComposeNavigatorTests {
             composeTestRule.waitForIdle()
 
             composeTestRule.onNodeWithText(dialog_text).assertDoesNotExist()
+        }
+    }
+
+    @Test
+    public fun goBackUntilTest() {
+        val go_to_second = composeTestRule.activity.getString(R.string.go_to_second)
+
+        fun getNextScreenText(route: StartRoute) : String {
+            return composeTestRule.activity.getString(R.string.navigate_to, route::class.simpleName.toString())
+        }
+
+        fun fillAll() {
+            val secondXClasses = StartRoute::class.nestedClasses.filter { it.simpleName?.contains("Second(\\d+)".toRegex()) == true }.sortedBy { it.simpleName }
+            secondXClasses.forEach { clazz ->
+                val nextScreen = getNextScreenText(clazz.createInstance() as StartRoute)
+                composeTestRule.onNodeWithText(nextScreen).performClick()
+                composeTestRule.waitForIdle()
+            }
+        }
+
+        composeTestRule.activity.apply {
+            composeTestRule.onNodeWithText(go_to_second).performClick()
+            composeTestRule.waitForIdle()
+
+            fillAll()
         }
     }
 }

--- a/navigator-compose/navigator-compose/src/androidTest/java/com/kpstv/navigation/compose/internels/Extensions.kt
+++ b/navigator-compose/navigator-compose/src/androidTest/java/com/kpstv/navigation/compose/internels/Extensions.kt
@@ -1,0 +1,3 @@
+package com.kpstv.navigation.compose.internels
+
+internal fun<K, V> Map<K,V>.lastValue(): V? = get(keys.lastOrNull())

--- a/navigator-compose/navigator-compose/src/androidTest/java/com/kpstv/navigation/compose/internels/MainActivity.kt
+++ b/navigator-compose/navigator-compose/src/androidTest/java/com/kpstv/navigation/compose/internels/MainActivity.kt
@@ -43,6 +43,18 @@ public sealed class StartRoute : Route {
     @Parcelize
     public data class Second(private val noArg: String = "") : StartRoute()
     @Parcelize
+    public data class Second1(private val noArg: String = "") : StartRoute()
+    @Parcelize
+    public data class Second2(private val noArg: String = "") : StartRoute()
+    @Parcelize
+    public data class Second3(private val noArg: String = "") : StartRoute()
+    @Parcelize
+    public data class Second4(private val noArg: String = "") : StartRoute()
+    @Parcelize
+    public data class Second5(private val noArg: String = "") : StartRoute()
+    @Parcelize
+    public data class Second6(private val noArg: String = "") : StartRoute()
+    @Parcelize
     public data class Third(private val noArg: String = "") : StartRoute()
     @Parcelize public data class Forth(private val noArg: String = "") : StartRoute()
     internal companion object {
@@ -62,6 +74,12 @@ public fun StartScreen(navigator: ComposeNavigator) {
                 goToForth = { controller.navigateTo(StartRoute.Forth()) }
             )
             is StartRoute.Second -> StartSecondScreen()
+            is StartRoute.Second1 -> StartSecondXScreen(dest::class.qualifiedName.toString(), StartRoute.Second2())
+            is StartRoute.Second2 -> StartSecondXScreen(dest::class.qualifiedName.toString(), StartRoute.Second3())
+            is StartRoute.Second3 -> StartSecondXScreen(dest::class.qualifiedName.toString(), StartRoute.Second4())
+            is StartRoute.Second4 -> StartSecondXScreen(dest::class.qualifiedName.toString(), StartRoute.Second5())
+            is StartRoute.Second5 -> StartSecondXScreen(dest::class.qualifiedName.toString(), StartRoute.Second6())
+            is StartRoute.Second6 -> StartSecondXScreen(dest::class.qualifiedName.toString(), null)
             is StartRoute.Third -> ThirdScreen()
             is StartRoute.Forth -> MultipleStackScreen()
         }
@@ -94,16 +112,33 @@ public fun StartSecondScreen() {
         }
         Button(onClick = {
             controller.navigateTo(StartRoute.Third()) {
-                popUpTo(controller.getAllHistory().first()) {
+                popUpTo(controller.getAllHistory().first()::class) {
                     inclusive = false // should be equivalent to history First, Third
                 }
             }
         }) {
             Text(text = stringResource(id = R.string.go_to_third))
         }
+        Button(onClick = { controller.navigateTo(StartRoute.Second1()) }) {
+            Text(text = stringResource(id = R.string.navigate_to, StartRoute.Second1::class.simpleName.toString()))
+        }
     }
 }
 
+@Composable
+public fun StartSecondXScreen(text: String, nextRoute: StartRoute?) {
+    val controller = findController(StartRoute.key)
+    Column {
+        Text(text = text)
+        if (nextRoute != null) {
+            Button(onClick = {
+                controller.navigateTo(nextRoute)
+            }) {
+                Text(text = stringResource(id = R.string.navigate_to, nextRoute::class.simpleName.toString()))
+            }
+        }
+    }
+}
 
 public sealed class ThirdRoute : Route {
     @Parcelize

--- a/navigator-compose/navigator-compose/src/androidTest/java/com/kpstv/navigation/compose/internels/MainActivity.kt
+++ b/navigator-compose/navigator-compose/src/androidTest/java/com/kpstv/navigation/compose/internels/MainActivity.kt
@@ -43,18 +43,6 @@ public sealed class StartRoute : Route {
     @Parcelize
     public data class Second(private val noArg: String = "") : StartRoute()
     @Parcelize
-    public data class Second1(private val noArg: String = "") : StartRoute()
-    @Parcelize
-    public data class Second2(private val noArg: String = "") : StartRoute()
-    @Parcelize
-    public data class Second3(private val noArg: String = "") : StartRoute()
-    @Parcelize
-    public data class Second4(private val noArg: String = "") : StartRoute()
-    @Parcelize
-    public data class Second5(private val noArg: String = "") : StartRoute()
-    @Parcelize
-    public data class Second6(private val noArg: String = "") : StartRoute()
-    @Parcelize
     public data class Third(private val noArg: String = "") : StartRoute()
     @Parcelize public data class Forth(private val noArg: String = "") : StartRoute()
     internal companion object {
@@ -74,12 +62,6 @@ public fun StartScreen(navigator: ComposeNavigator) {
                 goToForth = { controller.navigateTo(StartRoute.Forth()) }
             )
             is StartRoute.Second -> StartSecondScreen()
-            is StartRoute.Second1 -> StartSecondXScreen(dest::class.qualifiedName.toString(), StartRoute.Second2())
-            is StartRoute.Second2 -> StartSecondXScreen(dest::class.qualifiedName.toString(), StartRoute.Second3())
-            is StartRoute.Second3 -> StartSecondXScreen(dest::class.qualifiedName.toString(), StartRoute.Second4())
-            is StartRoute.Second4 -> StartSecondXScreen(dest::class.qualifiedName.toString(), StartRoute.Second5())
-            is StartRoute.Second5 -> StartSecondXScreen(dest::class.qualifiedName.toString(), StartRoute.Second6())
-            is StartRoute.Second6 -> StartSecondXScreen(dest::class.qualifiedName.toString(), null)
             is StartRoute.Third -> ThirdScreen()
             is StartRoute.Forth -> MultipleStackScreen()
         }
@@ -118,24 +100,6 @@ public fun StartSecondScreen() {
             }
         }) {
             Text(text = stringResource(id = R.string.go_to_third))
-        }
-        Button(onClick = { controller.navigateTo(StartRoute.Second1()) }) {
-            Text(text = stringResource(id = R.string.navigate_to, StartRoute.Second1::class.simpleName.toString()))
-        }
-    }
-}
-
-@Composable
-public fun StartSecondXScreen(text: String, nextRoute: StartRoute?) {
-    val controller = findController(StartRoute.key)
-    Column {
-        Text(text = text)
-        if (nextRoute != null) {
-            Button(onClick = {
-                controller.navigateTo(nextRoute)
-            }) {
-                Text(text = stringResource(id = R.string.navigate_to, nextRoute::class.simpleName.toString()))
-            }
         }
     }
 }

--- a/navigator-compose/navigator-compose/src/androidTest/java/com/kpstv/navigation/compose/internels/Routes.kt
+++ b/navigator-compose/navigator-compose/src/androidTest/java/com/kpstv/navigation/compose/internels/Routes.kt
@@ -1,0 +1,27 @@
+package com.kpstv.navigation.compose.internels
+
+import com.kpstv.navigation.compose.DialogRoute
+import kotlinx.parcelize.Parcelize
+import kotlin.reflect.KClass
+
+public class DialogRoutes {
+    @Parcelize
+    public object FirstDialog: DialogRoute {
+        public val key: KClass<FirstDialog> get() = FirstDialog::class
+    }
+
+    @Parcelize
+    public object SecondDialog: DialogRoute {
+        public val key: KClass<SecondDialog> get() = SecondDialog::class
+    }
+
+    @Parcelize
+    public object ThirdDialog: DialogRoute {
+        public val key: KClass<ThirdDialog> get() = ThirdDialog::class
+    }
+
+    @Parcelize
+    public object ForthDialog: DialogRoute {
+        public val key: KClass<ForthDialog> get() = ForthDialog::class
+    }
+}

--- a/navigator-compose/navigator-compose/src/androidTest/res/values/strings.xml
+++ b/navigator-compose/navigator-compose/src/androidTest/res/values/strings.xml
@@ -14,4 +14,5 @@
     <string name="choose_item">Choose an item</string>
     <string name="dismiss_dialog">Dismiss request dialog</string>
     <string name="navigation_dialog">Navigation dialog</string>
+    <string name="navigate_to">Navigate to: %1$s</string>
 </resources>

--- a/navigator-compose/navigator-compose/src/test/java/com/kpstv/navigation/compose/ComposeNavigatorUnitTests.kt
+++ b/navigator-compose/navigator-compose/src/test/java/com/kpstv/navigation/compose/ComposeNavigatorUnitTests.kt
@@ -1,0 +1,68 @@
+package com.kpstv.navigation.compose
+
+import android.os.Bundle
+import com.kpstv.navigation.compose.internals.*
+import org.junit.Test
+
+public class ComposeNavigatorUnitTests {
+  @Test
+  public fun `History Pop & PopUntil Test`() {
+    val history = ComposeNavigator.History(TestRoute.key, null, TestRoute.First(""))
+    history.push(TestRoute.Second())
+    history.push(TestRoute.Second1())
+    history.push(TestRoute.Second2())
+    history.push(TestRoute.Second3())
+    history.push(TestRoute.Second4())
+    history.push(TestRoute.Second5())
+
+    assert(history.peek().key is TestRoute.Second5)
+
+    var last = history.pop()!!
+
+    assert(history.peek().key is TestRoute.Second4)
+    assert(history.getCurrentRecord().key == last.key)
+
+    last = history.peek()
+    history.popUntil(TestRoute.Second::class, inclusive = true)
+
+    assert(history.peek().key is TestRoute.First)
+    assert(history.getCurrentRecord().key == last.key)
+    assert(history.pop() == null)
+
+    history.push(TestRoute.Second1())
+    history.push(TestRoute.Second2())
+    history.push(TestRoute.Second3())
+    history.push(TestRoute.Second4())
+    history.push(TestRoute.Second5())
+
+    history.popUntil(TestRoute.Second2::class, inclusive = false)
+
+    assert(history.peek().key is TestRoute.Second2)
+  }
+
+  @Test
+  public fun `DialogHistory 'clear' test`() {
+    val dialogHistory = ComposeNavigator.History.DialogHistory()
+    dialogHistory.createDialogScope(FirstDialog) { false }
+    dialogHistory.createDialogScope(SecondDialog) { false }
+    dialogHistory.createDialogScope(ThirdDialog) { false }
+    dialogHistory.createDialogScope(ForthDialog) { false }
+
+    assert(dialogHistory.getScopes().count() == 4)
+
+    dialogHistory.add(FirstDialog)
+    dialogHistory.add(SecondDialog)
+    dialogHistory.add(ThirdDialog)
+    dialogHistory.add(ForthDialog)
+
+    assert(dialogHistory.peek() is ForthDialog)
+
+    dialogHistory.clear()
+
+    assert(dialogHistory.isEmpty())
+  }
+
+  private fun ComposeNavigator.History<*>.push(route: TestRoute) {
+    this::class.members.find { it.name == "push" }?.call(this, ComposeNavigator.History.BackStackRecord(route))
+  }
+}

--- a/navigator-compose/navigator-compose/src/test/java/com/kpstv/navigation/compose/internals/Routes.kt
+++ b/navigator-compose/navigator-compose/src/test/java/com/kpstv/navigation/compose/internals/Routes.kt
@@ -1,0 +1,46 @@
+package com.kpstv.navigation.compose.internals
+
+import com.kpstv.navigation.compose.DialogRoute
+import com.kpstv.navigation.compose.Route
+import kotlinx.parcelize.Parcelize
+import kotlin.reflect.KClass
+
+public sealed class TestRoute : Route {
+    @Parcelize
+    public data class First(val data: String) : TestRoute()
+    @Parcelize
+    public data class Second(private val noArg: String = "") : TestRoute()
+    @Parcelize
+    public data class Second1(private val noArg: String = "") : TestRoute()
+    @Parcelize
+    public data class Second2(private val noArg: String = "") : TestRoute()
+    @Parcelize
+    public data class Second3(private val noArg: String = "") : TestRoute()
+    @Parcelize
+    public data class Second4(private val noArg: String = "") : TestRoute()
+    @Parcelize
+    public data class Second5(private val noArg: String = "") : TestRoute()
+    internal companion object {
+        val key = TestRoute::class
+    }
+}
+
+@Parcelize
+public object FirstDialog: DialogRoute {
+    public val key: KClass<FirstDialog> get() = FirstDialog::class
+}
+
+@Parcelize
+public object SecondDialog: DialogRoute {
+    public val key: KClass<SecondDialog> get() = SecondDialog::class
+}
+
+@Parcelize
+public object ThirdDialog: DialogRoute {
+    public val key: KClass<ThirdDialog> get() = ThirdDialog::class
+}
+
+@Parcelize
+public object ForthDialog: DialogRoute {
+    public val key: KClass<ForthDialog> get() = ForthDialog::class
+}

--- a/navigator-compose/samples/basic-sample/src/main/java/com/kpstv/navigation/compose/sample/MainActivity.kt
+++ b/navigator-compose/samples/basic-sample/src/main/java/com/kpstv/navigation/compose/sample/MainActivity.kt
@@ -35,6 +35,7 @@ import com.kpstv.navigation.compose.sample.ui.galleryItems
 import com.kpstv.navigation.compose.sample.ui.theme.ComposeTestAppTheme
 import com.kpstv.navigation.compose.*
 import com.kpstv.navigation.compose.sample.ui.MenuItem
+import com.kpstv.navigation.compose.sample.ui.screens.SettingScreen
 import kotlinx.parcelize.Parcelize
 
 class MainActivity : ComponentActivity() {
@@ -227,7 +228,7 @@ fun SecondScreen() {
                 when (dest) {
                     is MenuItem.Home -> Gallery()
                     is MenuItem.Favourite -> FavouriteMenuItem()
-                    else -> ReusableComponent(dest.toString())
+                    is MenuItem.Settings -> SettingScreen()
                 }
             }
         }
@@ -500,19 +501,6 @@ fun FavouriteMenuItem() {
                 }
             }
         }
-    }
-}
-
-@Composable
-fun ReusableComponent(text: String) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(Color.Black),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Text(text)
     }
 }
 

--- a/navigator-compose/samples/basic-sample/src/main/java/com/kpstv/navigation/compose/sample/ui/screens/SettingMenuScreen.kt
+++ b/navigator-compose/samples/basic-sample/src/main/java/com/kpstv/navigation/compose/sample/ui/screens/SettingMenuScreen.kt
@@ -1,0 +1,80 @@
+package com.kpstv.navigation.compose.sample.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.kpstv.navigation.compose.*
+import com.kpstv.navigation.compose.sample.StartRoute
+import com.kpstv.navigation.compose.sample.ui.MenuItem
+import kotlinx.parcelize.Parcelize
+
+sealed class SettingRoute : Route {
+    @Parcelize @Immutable
+    data class First(private val noArg: String = "") : SettingRoute()
+    @Parcelize @Immutable
+    data class Second(private val noArg: String = "") : SettingRoute()
+    companion object { val key = SettingRoute::class }
+}
+
+@Composable
+fun SettingScreen() {
+    val navigator = findComposeNavigator()
+    val settingController = rememberNavController<SettingRoute>()
+    navigator.Setup(key = SettingRoute.key, controller = settingController, initial = SettingRoute.First()) { dest ->
+        when(dest) {
+            is SettingRoute.First -> FirstSettingScreen()
+            is SettingRoute.Second -> SecondSettingScreen()
+        }
+    }
+}
+
+@OptIn(UnstableNavigatorApi::class)
+@Composable
+private fun FirstSettingScreen() {
+    val navigator = findComposeNavigator()
+    val settingController = findController(key = SettingRoute.key)
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Button(onClick = { settingController.navigateTo(SettingRoute.Second()) {
+            withAnimation {
+                target = Fade
+                current = Fade
+            }
+        } }) {
+            Text(text = "Go to Settings:Second")
+        }
+        Spacer(modifier = Modifier.height(10.dp))
+        Button(onClick = { navigator.goBackUntil(StartRoute.Second::class, inclusive = false) }) { // equivalent to "navigator.goBackUntil(MenuItem.Home::class)"
+            Text(text = "Go to StartRoute:Second navigation")
+        }
+    }
+}
+
+@OptIn(UnstableNavigatorApi::class)
+@Composable
+private fun SecondSettingScreen() {
+    val navigator = findComposeNavigator()
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.DarkGray),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Button(onClick = { navigator.goBackUntil(MenuItem.Home::class, inclusive = false) }) {
+            Text(text = "Go to Menu screen: Home")
+        }
+    }
+}


### PR DESCRIPTION
**Breaking Change**
- `popUpTo` now accepts `Route::class`. This was very sketchy when first designed. I haven't given it much a thought but was greatly pointed by @Tolriq (#16)

**Added**
- Certain internal APIs like `navigator.goBack()` is now exposed. Example usage would be to manage `onBackPressed` manually instead of depending on built-in `BackPressDispatcher` logic which is sketchy, [source](https://twitter.com/Zhuinden/status/1440540181073858568?s=20).
- `Controller<T>` has a new API `goBackUntil(dest)` which works essentially like `popUntil`, can be used to manage backstack for the current navigation setup.
- `ComposeNavigator` has a new API `goBackUntil(dest)` same as `Controller<T>`'s one but can be used as `popUntil` for a complete navigation system including nested ones with proper back animation (check sample > Settings screen). Although the API is stable & is [tested](https://github.com/KaustubhPatange/navigator/blob/8de02af1bd91c200aae8e098050ee36a024e5bbd/navigator-compose/navigator-compose/src/androidTest/java/com/kpstv/navigation/compose/ComposeNavigatorTests.kt#L412-L500) with many edges, I still believe it may not produce the correct result. This doesn't mean you shouldn't use it but make sure to test the API before making any commitment.

**What's remaining**
- Jump to root like functionality for both `Controller<T>` & `ComposeNavigator`.
- Any suggestions appreciated.