### PR TITLE
Fix: Proper lifecycle handling/creation on destination (navigator-compose)

### DIFF
--- a/navigator-compose/build.gradle
+++ b/navigator-compose/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         lintVersion = '30.1.0-alpha03'
         compose_version = '1.1.1'
         versions = [
-                "navigator_compose": "0.1-alpha34"
+                "navigator_compose": "0.1-alpha36"
         ]
     }
     repositories {

--- a/navigator-compose/navigator-compose/src/main/java/com/kpstv/navigation/compose/ComposeNavigator.kt
+++ b/navigator-compose/navigator-compose/src/main/java/com/kpstv/navigation/compose/ComposeNavigator.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.*
 import androidx.compose.ui.util.fastAny
 import androidx.compose.ui.util.fastForEach
-import androidx.compose.ui.util.fastMap
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.*
@@ -35,8 +34,6 @@ import com.kpstv.navigation.compose.Route.Key
 import kotlinx.coroutines.flow.*
 import kotlinx.parcelize.Parcelize
 import java.util.concurrent.ConcurrentHashMap
-import kotlin.contracts.ExperimentalContracts
-import kotlin.contracts.contract
 import kotlin.reflect.KClass
 
 /**

--- a/navigator-compose/navigator-compose/src/main/java/com/kpstv/navigation/compose/ComposeNavigator.kt
+++ b/navigator-compose/navigator-compose/src/main/java/com/kpstv/navigation/compose/ComposeNavigator.kt
@@ -1205,13 +1205,11 @@ public class ComposeNavigator private constructor(private val activity: Componen
         }
         override fun onActivityResumed(act: Activity) {
             if (activity === act) {
-                android.util.Log.e("Activity", "=> Resume()")
                 handleLastRouteLifecycleEvent(Lifecycle.Event.ON_RESUME)
             }
         }
         override fun onActivityPaused(act: Activity) {
             if (activity === act) {
-                android.util.Log.e("Activity", "=> Paused()")
                 handleLastRouteLifecycleEvent(Lifecycle.Event.ON_PAUSE)
             }
         }
@@ -1329,9 +1327,7 @@ public class ComposeNavigator private constructor(private val activity: Componen
                     CommonEffect(targetState = record.key, animation = animation, isBackward = history.lastTransactionStatus == History.NavType.Backward) { peek ->
                         val stateHolderObserver = remember(peek) { object : LifecycleEventObserver {
                             override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
-                                android.util.Log.e("LifecycleEvent", "${record.key::class.qualifiedName} -> $event")
                                 if (event == Lifecycle.Event.ON_DESTROY) {
-                                    android.util.Log.e("Disposing", "${record.key::class.qualifiedName} : ${record.key}")
                                     saveableStateHolder.removeState(record.key)
                                     source.lifecycle.removeObserver(this)
                                 }
@@ -1344,7 +1340,6 @@ public class ComposeNavigator private constructor(private val activity: Componen
                             // in any case if it is null we must restore an empty state.
                             if (!lifecycleController.isRestored()) {
                                 lifecycleController.performRestore(null)
-                                android.util.Log.e("Log", "Adding Observer")
                                 lifecycleController.lifecycle.addObserver(stateHolderObserver)
 
                                 // onCreate()
@@ -1362,7 +1357,6 @@ public class ComposeNavigator private constructor(private val activity: Componen
                         DisposableEffect(peek) {
                             currentNavRoute = peek
                             if (peek.lifecycleController.lifecycle.currentState != Lifecycle.State.RESUMED) {
-                                android.util.Log.e("Moving", "State => RESUME")
                                 peek.lifecycleController.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
                             }
 

--- a/navigator-compose/navigator-compose/src/main/java/com/kpstv/navigation/compose/ComposeNavigator.kt
+++ b/navigator-compose/navigator-compose/src/main/java/com/kpstv/navigation/compose/ComposeNavigator.kt
@@ -16,13 +16,14 @@ import androidx.compose.animation.core.*
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.runtime.*
-import androidx.compose.runtime.saveable.SaveableStateHolder
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.*
+import androidx.compose.ui.util.fastAny
 import androidx.compose.ui.util.fastForEach
+import androidx.compose.ui.util.fastMap
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.*
@@ -34,6 +35,8 @@ import com.kpstv.navigation.compose.Route.Key
 import kotlinx.coroutines.flow.*
 import kotlinx.parcelize.Parcelize
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
 import kotlin.reflect.KClass
 
 /**
@@ -743,9 +746,11 @@ public class ComposeNavigator private constructor(private val activity: Componen
             }
             navigator.backStackMap.bringToTop(routeKey)
 
-            // move previous key from history to onStop()
-            val previousKey = snapshot[maxOf(0, snapshot.lastIndex - 1)].key
-            previousKey.lifecycleController.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+            // recursively onStop previous key & it's associated children
+            if (snapshot.size > 1) {
+                val previousKey = snapshot[maxOf(0, snapshot.lastIndex - 1)].key
+                navigator.recursiveHandleLifecycleEvent(previousKey, Lifecycle.Event.ON_STOP)
+            }
 
             history.set(snapshot, History.NavType.Forward)
         }
@@ -967,15 +972,11 @@ public class ComposeNavigator private constructor(private val activity: Componen
         }
 
         if (backStackMap.size > 1 && !last!!.canGoBack()) {
-            val backstack = backStackMap.removeLastOrNull()?.get()
-            if (backstack != null) {
-                removeStateAndConfiguration(backstack.map { it.key })
-            }
+            backStackMap.removeLastOrNull()
             return goBack()
         }
 
         val popped = last?.pop()
-        popped?.let { removeStateAndConfiguration(it.key) }
         last?.let { _ ->
             val currentLastKey = last.get().last().key::class
             var associateKey: RouteKey<out Route>? = null
@@ -1192,7 +1193,7 @@ public class ComposeNavigator private constructor(private val activity: Componen
         private fun handleLastRouteLifecycleEvent(event: Lifecycle.Event) {
             val route = getAllHistory().lastOrNull() ?: return
             if (route.lifecycleController.isRestored()) {
-                route.lifecycleController.handleLifecycleEvent(event)
+                recursiveHandleLifecycleEvent(route, event)
             }
         }
 
@@ -1204,11 +1205,13 @@ public class ComposeNavigator private constructor(private val activity: Componen
         }
         override fun onActivityResumed(act: Activity) {
             if (activity === act) {
+                android.util.Log.e("Activity", "=> Resume()")
                 handleLastRouteLifecycleEvent(Lifecycle.Event.ON_RESUME)
             }
         }
         override fun onActivityPaused(act: Activity) {
             if (activity === act) {
+                android.util.Log.e("Activity", "=> Paused()")
                 handleLastRouteLifecycleEvent(Lifecycle.Event.ON_PAUSE)
             }
         }
@@ -1225,15 +1228,30 @@ public class ComposeNavigator private constructor(private val activity: Componen
         }
     }
 
-    private fun removeStateAndConfiguration(vararg items: Route) {
-        removeStateAndConfiguration(items.toList())
-    }
-    private fun removeStateAndConfiguration(items: List<Route>) {
-        items.fastForEach { route ->
-            val lifecycleController = route.lifecycleController
-            if (::saveableStateHolder.isInitialized) {
-                saveableStateHolder.removeState(route)
+    private fun recursiveHandleLifecycleEvent(key: Route, event: Lifecycle.Event) {
+        key.lifecycleController.handleLifecycleEvent(event)
+        // 1. manage lifecycles of descendants
+        // 2. manage lifecycles of ascendants, for eg: if "key" is first key of nested navigation
+        //    then also change lifecycle of its parent.
+        for (history in backStackMap.values) {
+            if (history.associateRoute === key) {
+                history.get().fastForEach { child ->
+                    recursiveHandleLifecycleEvent(child.key, event)
+                }
             }
+            if (history.get().firstOrNull()?.key === key && history.associateRoute != null) {
+                history.associateRoute.lifecycleController.handleLifecycleEvent(event)
+            }
+        }
+    }
+
+    private fun removeStateAndConfiguration(vararg items: Route, filterByCurrent: Boolean = true) {
+        removeStateAndConfiguration(items.toList(), filterByCurrent)
+    }
+    private fun removeStateAndConfiguration(items: List<Route>, filterByCurrent: Boolean = true) {
+        items.fastForEach { route ->
+            if (filterByCurrent && route === currentNavRoute) return@fastForEach
+            val lifecycleController = route.lifecycleController
             if (!activity.isChangingConfigurations) {
                 lifecycleController.clearViewModelStore()
             }
@@ -1245,9 +1263,9 @@ public class ComposeNavigator private constructor(private val activity: Componen
     }
 
     internal val backStackMap = mutableMapOf<RouteKey<out Route>, History<*>>()
-    private lateinit var saveableStateHolder: SaveableStateHolder
     private val navigatorTransitions: ArrayList<NavigatorTransition> = arrayListOf()
     private var savedState: Bundle? = null
+    private var currentNavRoute: Route? = null
 
     init {
         activity.onBackPressedDispatcher.addCallback(backPressHandler)
@@ -1309,19 +1327,49 @@ public class ComposeNavigator private constructor(private val activity: Componen
                 if (backStackMap.containsKey(key)) {
                     val animation = if (history.lastTransactionStatus == History.NavType.Forward) record.animation else history.getCurrentRecord().animation
                     CommonEffect(targetState = record.key, animation = animation, isBackward = history.lastTransactionStatus == History.NavType.Backward) { peek ->
+                        val stateHolderObserver = remember(peek) { object : LifecycleEventObserver {
+                            override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+                                android.util.Log.e("LifecycleEvent", "${record.key::class.qualifiedName} -> $event")
+                                if (event == Lifecycle.Event.ON_DESTROY) {
+                                    android.util.Log.e("Disposing", "${record.key::class.qualifiedName} : ${record.key}")
+                                    saveableStateHolder.removeState(record.key)
+                                    source.lifecycle.removeObserver(this)
+                                }
+                            }
+                        } }
+
                         val lifecycleController = remember(peek) {
                             val lifecycleController = peek.lifecycleController
                             // since restoring of savedStateRegistry happens when history is created when savedState is not null.
                             // in any case if it is null we must restore an empty state.
                             if (!lifecycleController.isRestored()) {
                                 lifecycleController.performRestore(null)
+                                android.util.Log.e("Log", "Adding Observer")
+                                lifecycleController.lifecycle.addObserver(stateHolderObserver)
+
+                                // onCreate()
+                                lifecycleController.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
                             }
-                            lifecycleController.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
-                            return@remember lifecycleController
+                            lifecycleController
                         }
+
                         CompositionLocalProvider(*lifecycleController.providers.toTypedArray()) {
                             saveableStateHolder.SaveableStateProvider(key = peek) {
                                 content(peek)
+                            }
+                        }
+
+                        DisposableEffect(peek) {
+                            currentNavRoute = peek
+                            if (peek.lifecycleController.lifecycle.currentState != Lifecycle.State.RESUMED) {
+                                android.util.Log.e("Moving", "State => RESUME")
+                                peek.lifecycleController.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+                            }
+
+                            onDispose {
+                                if (!history.get().fastAny { it.key == record.key }) {
+                                    removeStateAndConfiguration(record.key, filterByCurrent = false)
+                                }
                             }
                         }
                     }
@@ -1330,15 +1378,15 @@ public class ComposeNavigator private constructor(private val activity: Componen
                     backPressHandler.isEnabled = canGoBack() // update if back press is enabled or not.
                     onDispose {
                         if (!backStackMap.containsKey(key)) {
-                            history.get().forEach { saveableStateHolder.removeState(it) }
-                        } else if (!history.get().contains(record)) {
-                            saveableStateHolder.removeState(record.key)
+                            history.get().forEach { record ->
+                                removeStateAndConfiguration(record.key, filterByCurrent = false)
+                            }
                         }
                     }
                 }
             }
         }
-        DisposableEffect(Unit) {
+        DisposableEffect(key) {
             onDispose { compositionLocalScopeList.remove(compositionLocalScope) }
         }
     }

--- a/navigator-compose/samples/basic-sample/src/androidTest/java/com/kpstv/navigation/compose/sample/test/UnifiedTests.kt
+++ b/navigator-compose/samples/basic-sample/src/androidTest/java/com/kpstv/navigation/compose/sample/test/UnifiedTests.kt
@@ -1,6 +1,7 @@
+@file:Suppress("invisible_reference", "invisible_member")
+
 package com.kpstv.navigation.compose.sample.test
 
-import android.util.Log
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -11,9 +12,13 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
+import com.kpstv.navigation.compose.LifecycleControllerStore
 import com.kpstv.navigation.compose.sample.MainActivity
+import com.kpstv.navigation.compose.sample.ui.componenets.MenuItem
 import com.kpstv.navigation.compose.sample.ui.screens.MainFirstRoute
 import com.kpstv.navigation.compose.sample.ui.screens.MainRoute
+import com.kpstv.navigation.compose.sample.ui.screens.MenuHomeRoute
+import com.kpstv.navigation.compose.sample.ui.screens.MenuHomeRouteKey
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -56,6 +61,61 @@ class UnifiedTests {
                     assert(lifecycle.currentState == Lifecycle.State.DESTROYED)
                 }
             }
+        }
+    }
+
+    @Test
+    fun correctLifecycleEventsTest() {
+        composeTestRule.activity.apply {
+            var states = navigator.getAllHistory().map { it.lifecycleController.lifecycle.currentState }
+
+            // When application starts all states should be resumed.
+            assert(states.all { it == Lifecycle.State.RESUMED })
+
+            // Activity onPause()
+            composeTestRule.activityRule.scenario.moveToState(Lifecycle.State.STARTED)
+            composeTestRule.waitForIdle()
+            // Verify if all incoming states are onPaused()
+            states = navigator.getAllHistory().map { it.lifecycleController.lifecycle.currentState }
+            assert(states.all { it == Lifecycle.State.STARTED })
+
+            // Activity onResume()
+            composeTestRule.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+
+            composeTestRule.onNodeWithText("Go to second screen").performClick()
+            composeTestRule.waitForIdle()
+
+            val mainFirstRouteHistory = navigator.getHistory(MainFirstRoute.key)
+            val mainFirstRoutePrimary = mainFirstRouteHistory.last()
+
+            assert(mainFirstRoutePrimary is MainFirstRoute.Primary)
+            // onPause()
+            assert(mainFirstRoutePrimary.lifecycleController.lifecycle.currentState == Lifecycle.State.CREATED)
+
+            with(navigator.getHistory(MainRoute.key)) {
+                assert(last() is MainRoute.Second)
+                assert(last().lifecycleController.lifecycle.currentState == Lifecycle.State.RESUMED)
+            }
+
+            with(navigator.getHistory(MenuItem.key)) {
+                assert(last() is MenuItem.Home)
+                assert(last().lifecycleController.lifecycle.currentState == Lifecycle.State.RESUMED)
+            }
+
+            with(navigator.getHistory(MenuHomeRouteKey.key)) {
+                assert(last() is MenuHomeRoute.Primary)
+                assert(last().lifecycleController.lifecycle.currentState == Lifecycle.State.RESUMED)
+            }
+
+            onBackPressed()
+            composeTestRule.waitForIdle()
+
+            // MenuHomeRoute.Primary, MenuItem.Home should be removed from LifecycleControllerStore
+            assert(LifecycleControllerStore.getSnapshot().keys.none { it is MenuHomeRoute.Primary })
+            assert(LifecycleControllerStore.getSnapshot().keys.none { it is MenuItem.Home })
+
+            // onResume()
+            assert(mainFirstRoutePrimary.lifecycleController.lifecycle.currentState == Lifecycle.State.RESUMED)
         }
     }
 }


### PR DESCRIPTION
### TODO:

- ~Remove logs~
- Find a better way to solve `removeStateAndConfiguration(filterByCurrent = false)` either exclude current destination when removing or keep using this.